### PR TITLE
fix: custom styles should allow to override other default styles

### DIFF
--- a/src/text.tsx
+++ b/src/text.tsx
@@ -46,13 +46,13 @@ export function Text(props: TextProps) {
     () => [
       alignCenter ? s.tc : alignRight ? s.tr : s.tl,
       fill && s.w100,
-      style,
       upperCase && { textTransform: 'uppercase' },
       bold && s.b,
       semiBold && s.fw5,
       thin && s.fw2,
       italic && s.i,
       textStyle,
+      style,
     ],
     [alignCenter, alignRight, fill, style, upperCase, bold, semiBold, thin, italic, textStyle],
   )


### PR DESCRIPTION
### Problem 

Unable to use a custom line-height (ie, `28px`)

### Description 

I believe custom styles provided via `style` should allow overriding system default styles in case needed. 
I understand we want to enforce system design standards. So, custom styles don't ruin things. 
I'll be happy to refactor if we got any better way to solve this. 
