### PR TITLE
fix: Force text style inheritance for nested `Text`s.

### DIFF
--- a/src/text.tsx
+++ b/src/text.tsx
@@ -21,6 +21,8 @@ export interface TextProps extends Pick<RNTextProps, 'onLayout'>, TextStyleProps
   onPress?: () => void
 }
 
+const TextAncestorStyleContext = React.createContext<TextStyle[]>([])
+
 export function Text(props: TextProps) {
   const {
     style,
@@ -40,10 +42,14 @@ export function Text(props: TextProps) {
     textColor,
   } = props
 
+  const defaultStyle = useTextStyle({ fontSize: 'normal', textColor: COLOR.SECONDARY })
+  const textAncestorStyle = React.useContext(TextAncestorStyleContext)
   const textStyle = useTextStyle({ ...props, fontSize, textColor })
 
   const composedStyle = useMemo(
     () => [
+      defaultStyle,
+      textAncestorStyle,
       alignCenter ? s.tc : alignRight ? s.tr : s.tl,
       fill && s.w100,
       upperCase && { textTransform: 'uppercase' },
@@ -54,19 +60,35 @@ export function Text(props: TextProps) {
       textStyle,
       style,
     ],
-    [alignCenter, alignRight, fill, style, upperCase, bold, semiBold, thin, italic, textStyle],
-  )
+    [
+      defaultStyle,
+      textAncestorStyle,
+      alignCenter,
+      alignRight,
+      fill,
+      upperCase,
+      bold,
+      semiBold,
+      thin,
+      italic,
+      textStyle,
+      style,
+    ],
+  ) as TextStyle[]
+
   if (props.children == null) {
     return null
   }
   return (
-    <RNText
-      style={composedStyle as never}
-      onPress={onPress}
-      numberOfLines={numberOfLines}
-      onLayout={onLayout}
-    >
-      {children}
-    </RNText>
+    <TextAncestorStyleContext.Provider value={composedStyle}>
+      <RNText
+        style={composedStyle as never}
+        onPress={onPress}
+        numberOfLines={numberOfLines}
+        onLayout={onLayout}
+      >
+        {children}
+      </RNText>
+    </TextAncestorStyleContext.Provider>
   )
 }

--- a/src/text.tsx
+++ b/src/text.tsx
@@ -52,8 +52,6 @@ export function Text(props: TextProps) {
       thin && s.fw2,
       italic && s.i,
       textStyle,
-      !fontSize && { fontSize: 'inherit' },
-      !textColor && { color: 'inherit' },
       style,
     ],
     [alignCenter, alignRight, fill, style, upperCase, bold, semiBold, thin, italic, textStyle],

--- a/src/text.tsx
+++ b/src/text.tsx
@@ -36,8 +36,8 @@ export function Text(props: TextProps) {
     onPress,
     numberOfLines,
     onLayout,
-    fontSize = 'normal',
-    textColor = COLOR.SECONDARY,
+    fontSize,
+    textColor,
   } = props
 
   const textStyle = useTextStyle({ ...props, fontSize, textColor })
@@ -52,6 +52,8 @@ export function Text(props: TextProps) {
       thin && s.fw2,
       italic && s.i,
       textStyle,
+      !fontSize && { fontSize: 'inherit' },
+      !textColor && { color: 'inherit' },
       style,
     ],
     [alignCenter, alignRight, fill, style, upperCase, bold, semiBold, thin, italic, textStyle],


### PR DESCRIPTION
This issue originally appeared [here](https://github.com/highlighter-inc/knowabouts/issues/432).
So, first of all, we should not use default `fontSize` and `textColor` values for every single **Text** element as _inline_ styles.

Now, take a look at the main issue: `react-native-web` has default _inline_ styles it applies to its **Text** component:

https://github.com/necolas/react-native-web/blob/a6c976416bcbc0e4f35f67e3fdff5758645f8550/packages/react-native-web/src/exports/Text/index.js#L167-L177

They use React context to determine whether to include these defaults or not, so they include these styles for the _very first_ **Text** component in the tree. Fortunately, our custom inline `style` property overrides theirs.

-----

We can not set styles globally. For web it is possible to do via CSS styles but we can not do anything similar in React Native. We can not put some sort of `fontSize: inherit` into the RN inline style (e.g. to override `react-native-web`'s `fontSize: 14`) because it simply doesn't support it. In other words, for mobile apps we _must_ put something into inline styles to override `react-native-web` inline styles.

Now when we removed default `fontSize`/`textColor` props assignment (which is inevitable step), we theoretically can require our developers to _always_ set these properties in _first_ **Text** component in hierarchy. Thus, they will always override `react-native-web`'s styles and the rest (nested) **Text** components will inherit these values. But:
1. It is not transparent.
2. It is annoying for developers to always "hardcode" defaults.
3. It is not flexible (if we want to change defaults at once) and this would be a major package change (as the whole app will be affected).

----

...So I decided to use a `React.context` and pass ancestor's text style to the children **Text** components.
It is back-compatible, it will allow to use default values, it also guarantees that `fontSize`/`textColor` (and whatever else) will always be set to override `react-native-web`'s defaults.

I checked how this change will work in the current app and, apparently, it works without regressions for web and mobile app in both light and dark themes. My search matches highlighting also works fine with this change.